### PR TITLE
bumped to vert.x 2.1.6 and redis 3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ groovyVersion=2.2.1
 gradleVersion=1.10
 
 # The version of Vert.x
-vertxVersion=2.1.2
+vertxVersion=2.1.5
 
 # The version of Vert.x test tools
 toolsVersion=2.0.3-final

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,4 +23,4 @@ vertxVersion=2.1.6
 toolsVersion=2.0.3-final
 
 # The version of JUnit
-junitVersion=4.11
+junitVersion=4.12

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ groovyVersion=2.2.1
 gradleVersion=1.10
 
 # The version of Vert.x
-vertxVersion=2.1.5
+vertxVersion=2.1.6
 
 # The version of Vert.x test tools
 toolsVersion=2.0.3-final

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ pullInDeps=true
 produceJar=true
 
 # The version of Groovy to use (if you are using Groovy)
-groovyVersion=2.2.1
+groovyVersion=2.3.11
 
 # Gradle version
 gradleVersion=1.10

--- a/mod/src/test/java/io/vertx/redis/RedisInfoTester.java
+++ b/mod/src/test/java/io/vertx/redis/RedisInfoTester.java
@@ -65,7 +65,7 @@ public class RedisInfoTester extends TestVerticle {
                 if (server == null) {
                     server = reply.body().getObject("value");
                 }
-                assertTrue(server.getString("redis_version").startsWith("2."));
+                assertTrue(server.getString("redis_version").startsWith("3."));
                 testComplete();
             }
         });


### PR DESCRIPTION
@pmlopes @purplefox 

I aligned this module to vertx 2.1.5. All tests are ok but one. I am using redis 3 and test counts on redis 2.

It would be nice to bump these versions and release it.

Thank you very much.